### PR TITLE
Some fixes and minor update to gui

### DIFF
--- a/Converter/Extension/DataBaseExtension.cs
+++ b/Converter/Extension/DataBaseExtension.cs
@@ -43,13 +43,13 @@ namespace Converter.Extension
             {
 
 
-                if (o.SchemaContains.Equals(string.Empty) == false && tbl.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(tbl.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (string.Empty.Equals(o.TableContains) == false && tbl.Name.Contains(o.TableContains) == false)
+                if (o.Tables.Count > 0 && !o.Tables.Contains(tbl.Name))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
@@ -81,13 +81,13 @@ namespace Converter.Extension
             foreach (Table tbl in tables)
             {
 
-                if (o.SchemaContains.Equals(string.Empty) == false && tbl.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(tbl.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (o.TableContains.Equals(string.Empty) == false && tbl.Name.Contains(o.TableContains) == false)
+                if (o.Tables.Count > 0 && !o.Tables.Contains(tbl.Name))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
@@ -119,13 +119,13 @@ namespace Converter.Extension
             foreach (UserDefinedTableType tbl in udtts)
             {
 
-                if (o.SchemaContains.Equals(string.Empty) == false && tbl.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(tbl.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (o.TableContains.Equals(string.Empty) == false && tbl.Name.Contains(o.TableContains) == false)
+                if (o.Tables.Count > 0 && !o.Tables.Contains(tbl.Name))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
@@ -168,7 +168,7 @@ namespace Converter.Extension
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (o.SchemaContains.Equals(string.Empty) == false && sp.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(sp.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
@@ -199,7 +199,6 @@ namespace Converter.Extension
             logger.SetMaxValue(logger.Counter);
 
             
-            
             foreach (StoredProcedure sp in sps)
             {
                 if (sp.IsSystemObject)
@@ -208,7 +207,7 @@ namespace Converter.Extension
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (o.SchemaContains.Equals(string.Empty) == false && sp.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(sp.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);
@@ -251,7 +250,7 @@ namespace Converter.Extension
                     logger.SetValue(logger.CurrentItem);
                     continue;
                 }
-                if (o.SchemaContains.Equals(string.Empty) == false && sp.Schema.Contains(o.SchemaContains) == false)
+                if (o.Schemas.Count > 0 && !o.Schemas.Contains(sp.Schema))
                 {
                     logger.CurrentItem++;
                     logger.SetValue(logger.CurrentItem);

--- a/Converter/Extension/Table extensions/TableExtension.cs
+++ b/Converter/Extension/Table extensions/TableExtension.cs
@@ -22,7 +22,6 @@ namespace Converter.Extension
                                       ILog logger,
                                       SqlServerMoFeatures enumFeatures)
         {
-            var retValue = false;
             var schemaName = self.Schema;
 
             if (inMemDatabase.Schemas.Contains(schemaName) == false)
@@ -130,6 +129,7 @@ namespace Converter.Extension
                         IndexType = IndexType.NonClusteredIndex,
                         IndexKeyType = IndexKeyType.None
                     };
+                    idx.IsUnique = i.IsUnique;
 
                     bool hasColumns = false;
                     foreach (IndexedColumn ic in i.IndexedColumns)
@@ -221,7 +221,6 @@ namespace Converter.Extension
                     var test = inMemDatabase.Tables[cnf.HelperTableName, cnf.HelperSchema];
                     inMemDatabase.ExecuteNonQuery(newTable.FullInsertStm(test.SelectStm(), hasIdentities,
                         cnf.FullName));
-                    retValue = true;
                     logger.Log("OK ", newTable.FName());
                     //
                 }
@@ -239,15 +238,13 @@ namespace Converter.Extension
                     if (Debugger.IsAttached)
                         Debugger.Break();
 
-
-                    return false;
                 }
             }
 
 
             newTable = null;
 
-            return retValue;
+            return error == "";
         }
 
         public static void SupportUnsupported(

--- a/Converter/Options/Options.cs
+++ b/Converter/Options/Options.cs
@@ -1,4 +1,6 @@
-﻿namespace Converter.Options
+﻿using System.Collections.Generic;
+
+namespace Converter.Options
 {
     public class Options
     {
@@ -13,7 +15,7 @@
 /*
         public bool DropOnDestination { get; set; } = false;
 */
-        public string SchemaContains { get; set; } = string.Empty;
-        public string TableContains { get; set; } = string.Empty;
+        public List<string> Schemas { get; set; } = new List<string>();
+        public List<string> Tables { get; set; } = new List<string>();
     }
 }

--- a/GuiTester/MainForm.Designer.cs
+++ b/GuiTester/MainForm.Designer.cs
@@ -57,8 +57,8 @@
             this.chkCopyData = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
             this.label8 = new System.Windows.Forms.Label();
-            this.txtTableContains = new System.Windows.Forms.TextBox();
-            this.txtSchema = new System.Windows.Forms.TextBox();
+            this.txtTables = new System.Windows.Forms.TextBox();
+            this.txtSchemas = new System.Windows.Forms.TextBox();
             this.Timer1 = new System.Windows.Forms.Timer(this.components);
             this.label7 = new System.Windows.Forms.Label();
             this.lblOveral = new System.Windows.Forms.Label();
@@ -299,8 +299,8 @@
             this.grpOptions.Controls.Add(this.chkCopyData);
             this.grpOptions.Controls.Add(this.label9);
             this.grpOptions.Controls.Add(this.label8);
-            this.grpOptions.Controls.Add(this.txtTableContains);
-            this.grpOptions.Controls.Add(this.txtSchema);
+            this.grpOptions.Controls.Add(this.txtTables);
+            this.grpOptions.Controls.Add(this.txtSchemas);
             this.grpOptions.Location = new System.Drawing.Point(300, 12);
             this.grpOptions.Name = "grpOptions";
             this.grpOptions.Size = new System.Drawing.Size(299, 315);
@@ -371,36 +371,36 @@
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(7, 235);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(83, 13);
+            this.label9.Size = new System.Drawing.Size(148, 13);
             this.label9.TabIndex = 45;
-            this.label9.Text = "Table contains :";
+            this.label9.Text = "Table list (comma separated) :";
             // 
             // label8
             // 
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(7, 196);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(95, 13);
+            this.label8.Size = new System.Drawing.Size(160, 13);
             this.label8.TabIndex = 45;
-            this.label8.Text = "Schema contains :";
+            this.label8.Text = "Schema list (comma separated) :";
             // 
-            // txtTableContains
+            // txtTables
             // 
-            this.txtTableContains.BackColor = System.Drawing.SystemColors.Control;
-            this.txtTableContains.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.txtTableContains.Location = new System.Drawing.Point(10, 251);
-            this.txtTableContains.Name = "txtTableContains";
-            this.txtTableContains.Size = new System.Drawing.Size(247, 20);
-            this.txtTableContains.TabIndex = 50;
+            this.txtTables.BackColor = System.Drawing.SystemColors.Control;
+            this.txtTables.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.txtTables.Location = new System.Drawing.Point(10, 251);
+            this.txtTables.Name = "txtTables";
+            this.txtTables.Size = new System.Drawing.Size(247, 20);
+            this.txtTables.TabIndex = 50;
             // 
-            // txtSchema
+            // txtSchemas
             // 
-            this.txtSchema.BackColor = System.Drawing.SystemColors.Control;
-            this.txtSchema.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.txtSchema.Location = new System.Drawing.Point(10, 212);
-            this.txtSchema.Name = "txtSchema";
-            this.txtSchema.Size = new System.Drawing.Size(247, 20);
-            this.txtSchema.TabIndex = 50;
+            this.txtSchemas.BackColor = System.Drawing.SystemColors.Control;
+            this.txtSchemas.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.txtSchemas.Location = new System.Drawing.Point(10, 212);
+            this.txtSchemas.Name = "txtSchemas";
+            this.txtSchemas.Size = new System.Drawing.Size(247, 20);
+            this.txtSchemas.TabIndex = 50;
             // 
             // Timer1
             // 
@@ -482,8 +482,8 @@
         private System.Windows.Forms.CheckBox chkCopyData;
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.TextBox txtTableContains;
-        private System.Windows.Forms.TextBox txtSchema;
+        private System.Windows.Forms.TextBox txtTables;
+        private System.Windows.Forms.TextBox txtSchemas;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.RadioButton rbExtendedProperies;
         private System.Windows.Forms.RadioButton rbRange;

--- a/GuiTester/MainForm.cs
+++ b/GuiTester/MainForm.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using Converter.Inputs;
 using Converter.DataAccess;
 using Converter.Enums;
+using System.Collections.Generic;
 // ReSharper disable RedundantAssignment
 
 namespace GuiTester
@@ -108,8 +109,8 @@ namespace GuiTester
                 _o.UseHashIndexes = Options.IndexDecision.ExtendedPropery;
 
             //o.DropOnDestination = chkDropOnDestination.Checked;
-            _o.SchemaContains = txtSchema.Text.Trim();
-            _o.TableContains = txtTableContains.Text.Trim();
+            _o.Schemas.AddRange(txtSchemas.Text.Trim().Split(','));
+            _o.Tables.AddRange(txtTables.Text.Trim().Split(','));
 
             Server server;
             try

--- a/WPFTester/MainWindow.xaml
+++ b/WPFTester/MainWindow.xaml
@@ -60,9 +60,9 @@
 
         <Label Content="Schema contains" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Grid.ColumnSpan="2" Margin="5,8"/>
 
-        <TextBox Height="22" Grid.Row="3" TextWrapping="Wrap"  Grid.Column="3" Width="219" Name="txtSchema" HorizontalAlignment="Right" Margin="0,10" VerticalAlignment="Center"/>
-        <Label Content="Table contains" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Grid.ColumnSpan="2" Margin="5,8" />
-        <TextBox Height="22" Grid.Row="4" TextWrapping="Wrap" Text="" Grid.Column="3" Width="219" Name="txtTable" HorizontalAlignment="Right" Margin="0,10" VerticalAlignment="Center"/>
+        <TextBox Height="22" Grid.Row="3" TextWrapping="Wrap"  Grid.Column="3" Width="200" Name="txtSchemas" HorizontalAlignment="Right" Margin="0,11,0,10" VerticalAlignment="Center"/>
+        <Label Content="Table list (comma separated list)" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Grid.ColumnSpan="2" Margin="5,8" />
+        <TextBox Height="22" Grid.Row="4" TextWrapping="Wrap" Text="" Grid.Column="3" Width="200" Name="txtTables" HorizontalAlignment="Right" Margin="0,10,0,11" VerticalAlignment="Center"/>
 
 
 

--- a/WPFTester/MainWindow.xaml.cs
+++ b/WPFTester/MainWindow.xaml.cs
@@ -103,9 +103,7 @@ namespace WPFTester
             //create options
             _o = new Options
             {
-                CopyData = chkCopyData.IsChecked == true,
-                TableContains = txtTable.Text.Trim(),
-                SchemaContains = txtSchema.Text.Trim()
+                CopyData = chkCopyData.IsChecked == true
             };
 
 
@@ -311,6 +309,10 @@ namespace WPFTester
             {
                 enumFeatures = SqlServerMoFeatures.SqlServer2017;
             }
+
+            _o.Schemas.AddRange(txtSchemas.Text.Trim().Split(','));
+            _o.Tables.AddRange(txtTables.Text.Trim().Split(','));
+
             _success = db.SwitchToMo(
                                     dbInMemory,
                                     this,
@@ -733,8 +735,8 @@ namespace WPFTester
             cmbAuth.IsEnabled = v;
             cmbDatabase.IsEnabled = v;
             cmbDestination.IsEnabled = v;
-            txtSchema.IsEnabled = v;
-            txtTable.IsEnabled = v;
+            txtSchemas.IsEnabled = v;
+            txtTables.IsEnabled = v;
             cmbIndexOptions.IsEnabled = v;
             chkCopyData.IsEnabled = v;
             chkNewDatabase.IsEnabled = v;


### PR DESCRIPTION
Hello,

this PR addresses some bugs I found when using your converter, plus a minor enhancement that allows you to specify a table/schema list instead of just a simple "contains" (that did not let you specifiy exactly which tables to convert..)

List of modifications:
ADD table and schema list (comma separated) instead of "contains"
ADD warning message when a delete action "NOT NULL" was set (instead of getting an exception from sql server)
FIX unique contraints on indexes were not preserved -- See TableExtension.cs:132
FIX just the first index was scanned and ported to _InMem database
FIX miscellaneous: the return value of migration functions was not consistent with error variable: sometimes the return value was false even when there was no error, resulting in bad output. Sometimes it was true even when there was an error...